### PR TITLE
fix: support pull_request_target case

### DIFF
--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -19,16 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Create Token for MasterpointBot App
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
-        id: generate-token
+      - name: Run Trunk Upgrade
+        uses: masterpointio/github-action-trunk-upgrade@fix/admin-permissions
         with:
-          app_id: ${{ secrets.MP_BOT_APP_ID }}
-          private_key: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}
-
-      - name: Upgrade
-        uses: trunk-io/trunk-action/upgrade@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
-        with:
-          github-token: ${{ steps.generate-token.outputs.token }}
-          reviewers: "@masterpointio/masterpoint-internal"
-          prefix: "chore: "
+          app-id: ${{ secrets.MP_BOT_APP_ID }}
+          app-private-key: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}
+          github-token: ${{ secrets.MASTERPOINT_TEAM_PAT }}
+          reviewers: "@masterpointio/masterpoint-open-source"

--- a/action.yaml
+++ b/action.yaml
@@ -33,10 +33,15 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         token: ${{ inputs.github_token }}
-        # For pull_request_target: checkout the actual PR code, not the base branch
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
-        # Support forks by using the head repository when available
-        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+        # In pull_request_target, use the base repo's synthetic merge ref to avoid cross-repo clones
+        # and to prevent running fork code with elevated credentials. Otherwise, fall back to sha.
+        ref: ${{ (github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.number)) || github.event.pull_request.head.sha || github.sha }}
+        # Always clone from the base repository to avoid permission issues with forks
+        repository: ${{ github.repository }}
+        # Do not persist credentials into the repo's local config (reduces risk of token exfiltration)
+        persist-credentials: false
+        # Faster, smaller checkout
+        fetch-depth: 1
 
     - name: Aqua Cache
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/action.yaml
+++ b/action.yaml
@@ -33,6 +33,10 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         token: ${{ inputs.github_token }}
+        # For pull_request_target: checkout the actual PR code, not the base branch
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        # Support forks by using the head repository when available
+        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
     - name: Aqua Cache
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3


### PR DESCRIPTION
## what

- When workflows use `pull_request_target` trigger (needed for accessing secrets), the default checkout behavior checks out the base branch (main) instead of the PR branch, causing tests to run against the wrong code. Updated the checkout step to explicitly check out the PR code when running in `pull_request_target context`, with proper fallbacks for other trigger types.

## why

- Check out the branch we actually want to test.

## references

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected checkout behavior for pull_request_target to use the PR head, improving accuracy for forked pull requests.

- Chores
  - Streamlined the Trunk upgrade workflow into a single step.
  - Switched to a secrets-based token for upgrades.
  - Updated default reviewers to the open-source group.
  - Removed the commit prefix configuration in the upgrade step.
  - Renamed the upgrade step for clarity and removed obsolete steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->