### PR TITLE
chore: add minReleaseAge to Renovate conf (INT-356)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,8 +1,7 @@
 {
   "extends": [
     "config:best-practices",
-    "github>aquaproj/aqua-renovate-config#2.7.5",
-    "helpers:pinGitHubActionDigests"
+    "github>aquaproj/aqua-renovate-config#2.7.5"
   ],
   "schedule": [
     "after 9am on the first day of the month"
@@ -12,6 +11,7 @@
   "addLabels": [
     "auto-upgrade"
   ],
+  "minimumReleaseAge": "3 days",
   "enabledManagers": [
     "github-actions"
   ],


### PR DESCRIPTION
## what

- Set `minimumReleaseAge`: `3 days` globally so Renovate waits 3 days after any release before opening an upgrade PR. This applies to all managed dependency types.
- Remove redundant `helpers:pinGitHubActionDigests`, since it is already handled since we use [config:best-practices](https://docs.renovatebot.com/presets-config/#configbest-practices), which includes it.

## why

The `minimumReleaseAge` window gives the community time to discover and report bugs or vulnerabilities in newly published releases before we adopt them. Without it, Renovate could open a PR for a release within minutes of it being published — before any post-release issues are known.

## references

- [INT-356](https://www.notion.so/masterpoint/Update-Renovate-configs-with-minimumReleaseAge-and-pinDigests-168a707e8c564134b3586fd6a2553233)
